### PR TITLE
Allow HTTP listen port to be defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ below.)
       -c, --config-file FILENAME       Alternative configuration file 
                                        (%/panoptimon.json)
       -D, --[no-]foreground            Don't daemonize (false)
+      -p, --http-port PORT             HTTP Port (8080)
           --collectors-dir DIR         Collectors directory (%/collectors)
           --plugins-dir DIR            Plugins directory (%/plugins)
           --list-collectors            list all collectors found

--- a/lib/panoptimon.rb
+++ b/lib/panoptimon.rb
@@ -26,6 +26,7 @@ def self.load_options (args)
     :plugins_dir    => '%/plugins',
     :collector_interval => 60,
     :collector_timeout  => 120,
+    :http_port      => 8080,
   }
 
   options = ->() {
@@ -44,6 +45,10 @@ def self.load_options (args)
       opts.on('-D', '--[no-]foreground',
         "Don't daemonize (#{not defaults[:daemonize]})"
       ) { |v| o[:daemonize] = ! v }
+
+      opts.on('-p', '--http-port PORT',
+        "HTTP Port (#{defaults[:http_port]})"
+      ) { |v| o[:http_port] = v }
 
       ['collectors', 'plugins'].each { |x|
         k = "#{x}_dir".to_sym

--- a/lib/panoptimon/http.rb
+++ b/lib/panoptimon/http.rb
@@ -10,8 +10,7 @@ class HTTP
   def initialize (args={})
     @match = []
     @mount = []
-    # TODO args[:config].http_port, ssl, etc
-    @http = Thin::Server.new('0.0.0.0', 8080, self, signals: false);
+    @http = Thin::Server.new('0.0.0.0', args, self, signals: false);
   end
 
   def start

--- a/lib/panoptimon/monitor.rb
+++ b/lib/panoptimon/monitor.rb
@@ -99,7 +99,7 @@ class Monitor
     return @http unless @http.nil?
     # TODO rescue LoadError => nicer error message
     require 'panoptimon/http'
-    @http = HTTP.new
+    @http = HTTP.new(config.http_port)
     logger.warn "Serving http on #{@http.hostport}"
     @http
   end


### PR DESCRIPTION
Some systems already have services listening on TCP 8080. Allow the HTTP port to be defined.