### PR TITLE
triton-cn-resouces: return zero if no metrics are found

### DIFF
--- a/collectors/triton-cn-resources/triton-cn-resources
+++ b/collectors/triton-cn-resources/triton-cn-resources
@@ -5,6 +5,7 @@ for CN in $( /opt/smartdc/bin/sdc-cnapi --no-headers /servers | json -aH uuid ) 
 
   for RES in unreserved_cpu unreserved_ram unreserved_disk ; do
     CAP=$( /opt/smartdc/bin/sdc-cnapi --no-headers /servers/$CN | json $RES )
+    [[ -z "${CAP}" ]] && CAP=0
     echo "{\"$NAME|$RES\": $CAP}"
   done
 


### PR DESCRIPTION
New compute nodes appear in CNAPI before they have any resource data
to provide. Just return zero in this case.