### PR TITLE
triton-health: full path to sdcadm

### DIFF
--- a/collectors/triton-health/triton-health
+++ b/collectors/triton-health/triton-health
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-HEALTH=$( sdcadm health -q > /dev/null 2>&1 )
+HEALTH=$( /opt/smartdc/bin/sdcadm health -q > /dev/null 2>&1 )
 
 if ! [ $? == "0" ] ; then
   echo '{"healthy": false }'


### PR DESCRIPTION
Adds full path to `sdcadm` so we don’t need to push updated `PATH` into pano.